### PR TITLE
feat: Dockerize PHP application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Use an official PHP image with Apache
+FROM php:8.0-apache
+
+# Install mysqli extension
+RUN docker-php-ext-install mysqli && docker-php-ext-enable mysqli
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Copy application files
+# First, copy the main application directory
+COPY msms/ /var/www/html/msms/
+# Copy SQL file - though it will be used by mysql container, good to have it in context if needed
+COPY SQL\ File/ /var/www/html/SQL\ File/
+# Copy install.php (though we aim to bypass its direct use)
+COPY install.php /var/www/html/install.php
+
+# Copy other root files if necessary (e.g., .htaccess if any, or other specific configurations)
+# For now, we assume the core app is in 'msms' and 'install.php' is at the root.
+# If there are other specific root files like a global index.php or .htaccess, they should be copied too.
+# Example: COPY .htaccess /var/www/html/
+
+# Ensure correct permissions for Apache if needed
+# RUN chown -R www-data:www-data /var/www/html
+# RUN chmod -R 755 /var/www/html
+
+# Expose port 80
+EXPOSE 80
+
+# Apache's default document root is /var/www/html.
+# The entrypoint is handled by the base image (starts Apache).
+# We might need to configure Apache to point to a subdirectory if the app's entry isn't at the root of /var/www/html.
+# For this project, it seems the main app is in /msms, so we might need to adjust Apache config or redirect.
+# However, install.php is at the root.
+# Let's assume for now that accessing /install.php or /msms/index.php directly is acceptable.
+# If a cleaner root path is needed, we'll adjust Apache's DocumentRoot or add a .htaccess redirect later.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,66 @@ This project is open source and available under the [MIT License](LICENSE).
 
 ---
 
+## 🐳 Docker Setup (Recommended)
+
+This project includes `Dockerfile` and `docker-compose.yml` for easy setup using Docker.
+
+### Prerequisites
+- Docker installed on your system.
+- Docker Compose installed on your system (usually included with Docker Desktop).
+
+### Steps:
+1.  **Clone the Repository**:
+    ```bash
+    git clone https://github.com/yeabkal1001/Men-Salon-Management-System-Project-PHP.git
+    cd Men-Salon-Management-System-Project-PHP
+    ```
+    *(If you've already cloned, navigate to the project root directory where `docker-compose.yml` is located.)*
+
+2.  **Build and Run Containers**:
+    Open a terminal in the project root directory and run:
+    ```bash
+    sudo docker compose up -d --build
+    ```
+    - This command will build the PHP application image and start the PHP application container and a MySQL database container.
+    - The `-d` flag runs the containers in detached mode (in the background).
+    - `--build` ensures the image is built if it doesn't exist or if the Dockerfile has changed.
+
+3.  **Accessing the Application**:
+    -   **Frontend**: Open your web browser and go to `http://localhost:8080/msms/`
+    -   **Admin Panel**: Open your web browser and go to `http://localhost:8080/msms/admin/`
+        -   **Default Admin Username**: `admin`
+        -   **Default Admin Password**: `Test@123` (as per existing documentation)
+
+    *Note: The application is mapped to port `8080` on your host machine. The `dbconnection.php` file is pre-configured in the Docker setup to connect to the MySQL container named `db` with user `msmsuser` and password `msmspassword` for the `msmsdb` database.*
+
+4.  **Database Initialization**:
+    The `msmsdb.sql` schema from the `sql_files` directory is automatically imported into the MySQL container when it first starts.
+
+5.  **Stopping the Application**:
+    To stop the containers, run the following command in the project root directory:
+    ```bash
+    sudo docker compose down
+    ```
+
+6.  **Viewing Logs**:
+    If you need to check the logs for the PHP application or MySQL database:
+    ```bash
+    sudo docker compose logs php
+    sudo docker compose logs db
+    ```
+    To follow logs in real-time:
+    ```bash
+    sudo docker compose logs -f php
+    ```
+
+### Notes for Docker Users:
+- The `install.php` script is **not** needed when using Docker, as the database connection (`msms/includes/dbconnection.php`) is pre-configured and the database schema is automatically imported.
+- The PHP application files (under `msms/`) are mounted as a volume into the `php` container. This means any changes you make to these files locally will be reflected immediately in the running container, which is useful for development.
+- The MySQL data is persisted in a Docker named volume called `db_data`.
+
+---
+
 **Developed with ❤️ by Yeabsira, Saliha & Mihret**
 
 *Making salon management simple and efficient!*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+
+services:
+  php:
+    build: .
+    container_name: msms_php
+    ports:
+      - "8080:80" # Map host port 8080 to container port 80
+    volumes:
+      # Mount the whole project directory to allow live code changes during development
+      # Note: Adjust if your local structure is different or for production.
+      - ./msms:/var/www/html/msms
+      - ./SQL\ File:/var/www/html/SQL\ File
+      - ./install.php:/var/www/html/install.php
+      # If other root files/dirs exist and need to be mapped:
+      # - ./some_other_file.php:/var/www/html/some_other_file.php
+      # - ./some_other_dir:/var/www/html/some_other_dir
+    depends_on:
+      - db
+    networks:
+      - app-network
+
+  db:
+    image: mysql:8.0
+    container_name: msms_db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword # Change this in a real production environment
+      MYSQL_DATABASE: msmsdb
+      MYSQL_USER: msmsuser
+      MYSQL_PASSWORD: msmspassword # Change this in a real production environment
+    volumes:
+      - ./sql_files/msmsdb.sql:/docker-entrypoint-initdb.d/msmsdb.sql
+      - db_data:/var/lib/mysql # Persist database data
+    networks:
+      - app-network
+
+volumes:
+  db_data: # Named volume for MySQL data
+
+networks:
+  app-network:
+    driver: bridge

--- a/msms/includes/dbconnection.php
+++ b/msms/includes/dbconnection.php
@@ -1,7 +1,17 @@
 <?php
-$con=mysqli_connect("localhost", "root", "", "msmsdb");
-if(mysqli_connect_errno()){
-echo "Connection Fail".mysqli_connect_error();
-}
+// Database credentials from docker-compose.yml
+$db_host = "db"; // Service name defined in docker-compose.yml
+$db_user = "msmsuser"; // As defined in docker-compose.yml
+$db_pass = "msmspassword"; // As defined in docker-compose.yml
+$db_name = "msmsdb"; // As defined in docker-compose.yml
 
-  ?>
+$con = mysqli_connect($db_host, $db_user, $db_pass, $db_name);
+
+if(mysqli_connect_errno()){
+  // It's better to log errors or handle them gracefully than echoing directly,
+  // but for keeping consistency with the original style:
+  echo "Connection Fail: " . mysqli_connect_error();
+  // Consider exiting or throwing an exception in a real application
+  // exit("Database connection failed: " . mysqli_connect_error());
+}
+?>


### PR DESCRIPTION
- Add Dockerfile for PHP-Apache setup with mysqli.
- Add docker-compose.yml for php and mysql services.
- Update dbconnection.php to use Docker service names and credentials.
- Rename 'SQL File' to 'sql_files' to avoid path issues in Docker.
- Update README.md with Docker usage instructions and path correction.